### PR TITLE
Enable command line specification of VCF files or callsetIds

### DIFF
--- a/calldiff/src/main/java/edu/berkeley/cs/amplab/calldiff/Main.java
+++ b/calldiff/src/main/java/edu/berkeley/cs/amplab/calldiff/Main.java
@@ -32,11 +32,11 @@ public class Main {
     if (!useVcfFile && !useCallset) {
       throw new IllegalStateException(
           String.format("Specify one of --%s_vcf or --%s_callset_id", name, name));
-    } else if (!useVcfFile && !useCallset) {
+    } else if (useVcfFile && !useCallset) {
       File file = new File(vcfFile.get());
       return sampleId.map(sample -> VcfCallScanner.create(file, sample))
           .orElse(VcfCallScanner.create(file));
-    } else if (!useVcfFile && !useCallset) {
+    } else if (!useVcfFile && useCallset) {
       return ApiCallScanner.create(createGenomics(commandLine.apiKey(),
           commandLine.clientSecretsFile(), commandLine.serviceAccountId(), commandLine.p12File(),
           commandLine.rootUrl(), commandLine.timeout()), callsetId.get());


### PR DESCRIPTION
The current logic rejects any specification of --lhs_\* and
--rhs_\* on the command line. This fixes the logic to be either/or, hopefully
as intended.
